### PR TITLE
Add Modules, Linecard and Routing-Engine

### DIFF
--- a/extensions/modules/README.md
+++ b/extensions/modules/README.md
@@ -1,0 +1,18 @@
+# 🧩 Modules
+
+This schema extension allows you to capture Device Modules related information like the serial number or the satus. You can insert the Module into a Dcim Physcial Device.
+
+> [!NOTE]
+> This extension doesn't contain any Node, you can use the extension module_linecards or modules_routing_engine to use it
+
+
+## Generics
+
+- DeviceGenericModule
+- DeviceGenericModuleType
+
+## Nodes
+
+## Dependencies
+
+- Base

--- a/extensions/modules/modules.yml
+++ b/extensions/modules/modules.yml
@@ -1,0 +1,118 @@
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+
+version: '1.0'
+
+generics:
+  - name: GenericModule
+    namespace: Device
+    description: "A generic module, such as a Linecard or Routing Engine, installed in a device."
+    label: "Module"
+    attributes:
+      - name: serial_number
+        kind: Text
+        unique: true
+        description: "Unique serial number of the module."
+        order_weight: 1000
+      - name: description
+        kind: Text
+        optional: true
+        order_weight: 1100
+      - name: status
+        kind: Dropdown
+        choices:
+          - name: provisioning
+            label: Provisioning
+            description: "Linecard is being provisioned."
+            color: "#A9DFBF"  # light pastel green
+          - name: active
+            label: Active
+            description: "Linecard is active and operational."
+            color: "#A9CCE3"  # pastel blue
+          - name: maintenance
+            label: Maintenance
+            description: "Linecard is under maintenance."
+            color: "#FFF2CC"  # pastel yellow
+          - name: disabled
+            label: Disabled
+            description: "Linecard has been disabled."
+            color: "#D3D3D3"  # light grey
+          - name: outage
+            label: Outage
+            description: "Linecard is currently experiencing an outage."
+            color: "#F4CCCC"  # pastel red
+        default_value: "active"
+        order_weight: 1300
+    relationships:
+      - name: module_type
+        peer: DeviceGenericModuleType
+        optional: false
+        cardinality: one
+        kind: Attribute
+        order_weight: 1150
+      - name: device
+        label: Device
+        peer: DcimPhysicalDevice
+        identifier: device__modules
+        # We could have module in the storage so Device should not be mandatory
+        optional: true
+        cardinality: one
+        kind: Attribute # Parent
+        order_weight: 1000
+
+  - name: GenericModuleType
+    namespace: Device
+    description: "A generic module type, such as a Linecard or Routing Engine, with common specifications like part number and manufacturer."
+    label: "Module Type"
+    uniqueness_constraints:
+      - ["part_number__value"]
+      - ["name__value", "manufacturer"]
+    human_friendly_id:
+      - name__value
+    order_by:
+      - manufacturer__name__value
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+        unique: true
+        description: "Name of the module type."
+        order_weight: 1000
+      - name: description
+        kind: Text
+        optional: true
+        description: "Description of the module type."
+        order_weight: 1100
+      - name: part_number
+        label: Part Number
+        kind: Text
+        optional: true
+        description: "Part number of the module."
+        order_weight: 1200
+    relationships:
+      - name: manufacturer
+        peer: OrganizationManufacturer
+        identifier: manufacturer__moduletype
+        cardinality: one
+        optional: false
+        kind: Attribute
+        description: "Manufacturer of the module type."
+        order_weight: 1250
+      - name: tags
+        peer: BuiltinTag
+        optional: true
+        cardinality: many
+        kind: Attribute
+        description: "Tags associated with the module type."
+        order_weight: 3000
+
+extensions:
+  nodes:
+    # DCIM Extensions
+    - kind: DcimPhysicalDevice
+      relationships:
+        - name: modules
+          peer: DeviceGenericModule
+          identifier: device__modules
+          cardinality: many
+          kind: Component

--- a/extensions/modules/modules.yml
+++ b/extensions/modules/modules.yml
@@ -62,7 +62,7 @@ generics:
 
   - name: GenericModuleType
     namespace: Device
-    description: "A generic module type, such as a Linecard or Routing Engine, with common specifications like part number and manufacturer."
+    description: "A generic module type, with common specifications like part number and manufacturer."
     label: "Module Type"
     uniqueness_constraints:
       - ["part_number__value"]

--- a/extensions/modules_linecards/README.md
+++ b/extensions/modules_linecards/README.md
@@ -1,0 +1,21 @@
+# 🧩 Linecard
+
+This schema extension allows you to capture Linecard related information like the version. You can insert the Linecard into a Dcim Physcial Device and leverage the Linecard type model.
+The Linecard can accept PIC to help configure PORT informations like breakout-capabilities and configurations
+
+
+## Generics
+
+- GenericPatchPanelInterface
+
+## Nodes
+
+- DcimLinecard
+- DcimLinecardType
+- DevicePic
+- DevicePort
+
+## Dependencies
+
+- Base
+- Modules

--- a/extensions/modules_linecards/linecard.yml
+++ b/extensions/modules_linecards/linecard.yml
@@ -1,0 +1,146 @@
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+
+version: '1.0'
+
+nodes:
+  - name: LinecardType
+    namespace: Device
+    description: "Linecard Type information, detailing specifications such as part number and manufacturer."
+    label: "Linecard Type"
+    inherit_from:
+      - DeviceGenericModuleType
+    relationships:
+      - name: linecards
+        peer: InfraLinecard
+        cardinality: many
+        kind: Generic
+        description: "Linecards of this type."
+
+  - name: Linecard
+    namespace: Device
+    description: "A Linecard installed in a device, specifying slot, power status, and functionalities."
+    label: "Linecard"
+    icon: "bi:pci-card"
+    inherit_from:
+      - DeviceGenericModule
+    uniqueness_constraints:
+      - ["serial_number__value"]
+      #  # Only one Linecard per Device Slot
+      # - ["device", "slot__value"]
+    human_friendly_id:
+      - device__name__value
+      - slot__value
+    order_by:
+      - device__name__value
+      - slot__value
+    display_labels:
+      - serial_number__value
+    attributes:
+      - name: slot
+        kind: Number
+        description: "The slot number where the Linecard is installed within the device"
+        order_weight: 1050
+      - name: bng_enabled
+        label: BNG Enabled
+        description: "BNG activated or deactivated on the Linecard"
+        kind: Boolean
+        optional: true
+        default_value: false
+        order_weight: 1400
+    relationships:
+      - name: linecard_type
+        label: Linecard Type
+        peer: DeviceLinecardType
+        optional: false
+        cardinality: one
+        kind: Attribute
+        order_weight: 1150
+      - name: pics
+        label: PICs
+        peer: DevicePic
+        optional: true
+        cardinality: many
+        # As there is not a lot of Attributes and it will stay a low number, using Attribute instead of Component
+        kind: Attribute
+        order_weight: 1500
+
+  # PIC (Physical Interface Card) model, representing submodules in the Linecard
+  - name: Pic
+    namespace: Device
+    description: "Physical Interface Card (PIC) installed in the Linecard, containing multiple ports."
+    label: "PIC"
+    uniqueness_constraints:
+      # Only one PIC per slot within a Linecard
+      - ["linecard", "slot__value"]
+    human_friendly_id:
+      - linecard__serial_number__value
+      - slot__value
+    display_labels:
+      - slot__value
+    order_by:
+      - linecard__serial_number__value
+      - slot__value
+    attributes:
+      - name: slot
+        kind: Number
+        description: "Slot number of the PIC within the Linecard"
+        order_weight: 1200
+    relationships:
+      - name: linecard
+        label: Linecard
+        peer: DeviceLinecard
+        identifier: linecard__pics
+        optional: false
+        cardinality: one
+        kind: Parent
+        order_weight: 1000
+      - name: ports
+        label: Ports
+        peer: InfraPort
+        optional: true
+        cardinality: many
+        kind: Component
+        order_weight: 1100
+
+  # Port model representing individual ports on a PIC
+  - name: Port
+    namespace: Device
+    description: "A network port on a PIC, specifying speed and port number."
+    label: "Port"
+    uniqueness_constraints:
+      - ["pic", "port_number__value"]  # Each port must be unique within a PIC
+    human_friendly_id:
+      - pic__slot__value
+      - port_number__value
+    display_labels:
+      - port_number__value
+    order_by:
+      - pic__slot__value
+      - port_number__value
+    attributes:
+      - name: port_number
+        kind: Number
+        description: "Port number on the PIC"
+        order_weight: 1100
+      - name: speed
+        kind: Dropdown
+        description: "Speed of the port"
+        choices:
+          - name: 10g
+            label: 10Gbps
+            description: "10 Gigabit per second"
+            color: "#A9CCE3"
+          - name: 100g
+            label: 100Gbps
+            description: "100 Gigabit per second"
+            color: "#9fbdf2"
+        order_weight: 1200
+    relationships:
+      - name: pic
+        label: PIC
+        peer: DevicePic
+        optional: false
+        cardinality: one
+        kind: Parent
+        order_weight: 1000

--- a/extensions/modules_routing_engine/README.md
+++ b/extensions/modules_routing_engine/README.md
@@ -1,0 +1,16 @@
+# 🧩 Routing Engine
+
+This schema extension allows you to capture Routing Engine related information like the version. You can insert the Routing Engine into a Dcim Physcial Device and leverage the Routing Engine type model.
+
+
+## Generics
+
+## Nodes
+
+- DeviceRoutingEngine
+- DeviceRoutingEngineType
+
+## Dependencies
+
+- Base
+- Modules

--- a/extensions/modules_routing_engine/routing_engine.yml
+++ b/extensions/modules_routing_engine/routing_engine.yml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: '1.0'
+
+nodes:
+  - name: RoutingEngineType
+    namespace: Device
+    description: "Routing Engine Type information, detailing specifications such as part number and manufacturer."
+    label: "Routing Engine Type"
+    inherit_from:
+      - DeviceGenericModuleType
+    relationships:
+      - name: routing_engines
+        peer: InfraRoutingEngine
+        cardinality: many
+        kind: Generic
+        description: "Routing engines of this type."
+
+  - name: RoutingEngine
+    namespace: Device
+    description: "A Routing Engine (RE) installed in a device, responsible for routing functionalities."
+    label: "Routing Engine"
+    icon: "mdi:cpu-64-bit"
+    inherit_from:
+      - DeviceGenericModule
+    uniqueness_constraints:
+      - ["serial_number__value"]
+      #  # Only one RE per Device RE-Slot
+      # - ["device", "slot__value"]
+    human_friendly_id:
+      - device__name__value
+      - slot__value
+    order_by:
+      - device__name__value
+      - slot__value
+    display_labels:
+      - serial_number__value
+    attributes:
+      - name: slot
+        kind: Number
+        description:  "The slot number where the Routing Engine is installed within the device"
+        order_weight: 1100
+      - name: version
+        kind: Text
+        label: Version
+        description: "Firmware version of the Routing Engine."
+        optional: true
+        order_weight: 1200
+    relationships:
+      - name: routing_engine_type
+        label: RE Type
+        peer: InfraRoutingEngineType
+        optional: false
+        cardinality: one
+        kind: Attribute
+        order_weight: 1150

--- a/extensions/modules_routing_engine/routing_engine.yml
+++ b/extensions/modules_routing_engine/routing_engine.yml
@@ -38,7 +38,7 @@ nodes:
     attributes:
       - name: slot
         kind: Number
-        description:  "The slot number where the Routing Engine is installed within the device"
+        description: "The slot number where the Routing Engine is installed within the device"
         order_weight: 1100
       - name: version
         kind: Text


### PR DESCRIPTION
Add 3 extensions
- Modules
- Modules Linecard
- Modules Routing-Engine

TODO: we could also use the Module extension for the Patch Panel, so a Patch Panel Module inherits from the DeviceModule.