### PR TITLE
fix: hide abstract DCIM generics from auto-menu to drop duplicate entries

### DIFF
--- a/base/dcim.yml
+++ b/base/dcim.yml
@@ -8,6 +8,7 @@ generics:
     description: Generic Device object.
     label: Device
     icon: mdi:server
+    include_in_menu: false
     human_friendly_id:
       - name__value
     order_by:

--- a/experimental/optical_transport/optical_transport.yml
+++ b/experimental/optical_transport/optical_transport.yml
@@ -23,7 +23,7 @@ generics:
     namespace: Dcim
     description: "Generic base for any channel allocation/routing (fiber, cable, or internal cross-connect)"
     label: "Channel Mapping"
-    include_in_menu: true
+    include_in_menu: false
     attributes:
       # TODO: Replace with a proper status
       - name: is_active
@@ -66,7 +66,7 @@ generics:
     namespace: Dcim
     description: "Generic interface for any device that can multiplex DWDM channels (active or passive)"
     label: "Optical Multiplexer Device"
-    include_in_menu: true
+    include_in_menu: false
     uniqueness_constraints:
       - [computed_name__value]
     attributes:


### PR DESCRIPTION
## Summary — `include_in_menu` cleanup on `ic-fix-display-menu`

### What changed

**Commit `a2c51cd` — `base/dcim.yml`**
Added `include_in_menu: false` to the `DcimGenericDevice` generic.

**Commit `0143c59` — `experimental/optical_transport/optical_transport.yml`**
Flipped `include_in_menu: true` → `false` on two generics:
- `DcimChannelMapping` (line 26)
- `DcimOpticalDevice` (line 69)

### Why

All three are **abstract generics** whose concrete descendants already render their own top-level menu entries without nesting via `menu_placement`. That means the Infrahub UI was showing two top-level entries pointing at the same records:

| Generic (was visible) | Concrete descendants (also top-level) |
|---|---|
| `DcimGenericDevice` | `DcimDevice` (rendered as "Network Device") |
| `DcimChannelMapping` | `DcimFiberMapping`, `DcimCableMapping`, `DcimWSSConnect` |
| `DcimOpticalDevice` | `DcimOpticalNode` |

Functional duplicates — clicking either entry surfaced the same data. Hiding the generic eliminates the duplicate without losing anything, since the descendants are the only data carriers.

### Consistency rationale

The `base/dcim.yml` file already opts every other abstract generic out of the menu (`DcimPhysicalDevice`, `DcimEndpoint`, `DcimConnector`, `DcimInterface`, `InterfaceLayer2/3`, etc.). `DcimGenericDevice` was the lone exception. The optical_transport generics followed the same anti-pattern. Both commits bring those generics in line with the established convention.

### What was deliberately left alone

Generics whose descendants nest under them via `menu_placement` (e.g. `ClusterGeneric`, `LocationGeneric`, `OrganizationGeneric`, `DcimGenericSFP`, `DcimGenericOadmInterface`, `DcimGenericPatchPanelInterface`, `NetworkManagementServer`, `TopologyNetworkStrategy`) act as real menu parents and must stay visible.

One mixed case remains — `DeviceGenericModule` in `extensions/modules/modules.yml` — where some descendants nest correctly and others (`DeviceRoutingEngine`, `DcimTransponderModule`) don't. That's a design call rather than a one-line fix; not addressed here.

### Direction this points toward

These changes are tactical fixes against the current `include_in_menu`-driven model. The stated goal is to have menus driven by `menu.yml` files instead, at which point `include_in_menu: false` would become the default for all abstract generics and explicit menu placement would live in the menu file. These two commits are a step in that direction without yet introducing the menu-file scaffolding.