### PR TITLE
fix(security): update stale Infra kind references to current Dcim/Ipam namespaces

### DIFF
--- a/experimental/security/security.yml
+++ b/experimental/security/security.yml
@@ -129,7 +129,7 @@ nodes:
         optional: true
     relationships:
       - name: ip_address
-        peer: InfraIPAddress
+        peer: IpamIPAddress
         cardinality: one
         kind: Attribute
         optional: false
@@ -150,7 +150,7 @@ nodes:
         optional: true
     relationships:
       - name: ip_prefix
-        peer: InfraPrefix
+        peer: IpamPrefix
         cardinality: one
         kind: Attribute
         optional: false
@@ -478,14 +478,15 @@ nodes:
   - name: Firewall
     namespace: Security
     inherit_from:
-      - InfraGenericDevice
+      - DcimGenericDevice
+      - DcimPhysicalDevice
       - CoreArtifactTarget
       - SecurityPolicyAssignment
     icon: "mdi:firewall"
     include_in_menu: true
     human_friendly_id:
       - name__value
-    menu_placement: "InfraGenericDevice"
+    menu_placement: "DcimGenericDevice"
     attributes:
       - name: role
         kind: Dropdown
@@ -603,16 +604,16 @@ nodes:
   - name: FirewallInterface
     namespace: Security
     label: Firewall Interface
-    menu_placement: "InfraGenericDevice"
+    menu_placement: "DcimGenericDevice"
     include_in_menu: false
     icon: "mdi:ethernet"
     display_label: name__value
     inherit_from:
-      - InfraInterface
-      - InfraEndpoint
+      - DcimInterface
+      - DcimEndpoint
     relationships:
       - name: ip_addresses
-        peer: InfraIPAddress
+        peer: IpamIPAddress
         optional: true
         cardinality: many
         kind: Component


### PR DESCRIPTION
The security extension failed to load because it referenced schema kinds from the old `Infra` namespace, which was renamed to `Dcim` (devices, interfaces, endpoints) and `Ipam` (IP addresses, prefixes) in an earlier base release. `security.yml` was not updated, so the load aborted with:

    SecurityFirewall Unable to find the generic InfraGenericDevice

Changes:
- InfraGenericDevice -> DcimGenericDevice (inherit_from + menu_placement)
- InfraInterface      -> DcimInterface
- InfraEndpoint      -> DcimEndpoint
- InfraIPAddress     -> IpamIPAddress
- InfraPrefix            -> IpamPrefix

Also add DcimPhysicalDevice to SecurityFirewall's inheritance, matching DcimDevice. The deployed schema already expects it; without it the load failed a second time with a node-level inherit_from constraint violation for trying to drop DcimPhysicalDevice from an existing node.