### PR TITLE
fix(experimental): make circuit_service and modules_routing_engine loadable

### DIFF
--- a/docs/docs/reference/circuit_service.mdx
+++ b/docs/docs/reference/circuit_service.mdx
@@ -36,7 +36,7 @@ For example you have a MPLS network supported by a provider connecting multiple 
 | name | peer | optional | cardinality | kind |
 | ---- | ---- | -------- | ----------- | ---- |
 | provider | OrganizationProvider | False | one | Attribute |
-| circuit_endpoints | CircuitEndpoint | True | many | Component |
+| circuit_endpoints | DcimCircuitEndpoint | True | many | Component |
 
 ## Extensions
 
@@ -54,7 +54,7 @@ In this context "extensions" refer to modifications or additions to the existing
 | ---- | ---- | -------- | ----------- | ---- |
 | circuit_services | CircuitService | True | many |  |
 
-### CircuitEndpoint
+### DcimCircuitEndpoint
 
 #### Relationships
 
@@ -96,7 +96,7 @@ nodes:
     cardinality: one
     kind: Attribute
   - name: circuit_endpoints
-    peer: CircuitEndpoint
+    peer: DcimCircuitEndpoint
     optional: true
     cardinality: many
     kind: Component
@@ -108,7 +108,7 @@ extensions:
       peer: CircuitService
       cardinality: many
       optional: true
-  - kind: CircuitEndpoint
+  - kind: DcimCircuitEndpoint
     relationships:
     - name: circuit_service
       peer: CircuitService

--- a/docs/docs/reference/modules_routing_engine.mdx
+++ b/docs/docs/reference/modules_routing_engine.mdx
@@ -33,7 +33,7 @@ This schema extension allows you to capture Routing Engine related information l
 - **Icon:** mdi:cpu-64-bit
 - **Uniqueness Constraints:**
     - serial_number__value
-- **Human Friendly ID:** device__name__value, slot__value
+- **Human Friendly ID:** serial_number__value
 - **Inherit From:** DeviceGenericModule
 
 #### Attributes
@@ -78,10 +78,9 @@ nodes:
   uniqueness_constraints:
   - - serial_number__value
   human_friendly_id:
-  - device__name__value
-  - slot__value
+  - serial_number__value
   order_by:
-  - device__name__value
+  - device__serial__value
   - slot__value
   display_label: serial_number__value
   attributes:

--- a/experimental/circuit_service/circuit_service.yml
+++ b/experimental/circuit_service/circuit_service.yml
@@ -30,7 +30,7 @@ nodes:
         cardinality: one
         kind: Attribute
       - name: circuit_endpoints
-        peer: CircuitEndpoint
+        peer: DcimCircuitEndpoint
         optional: true
         cardinality: many
         kind: Component
@@ -43,7 +43,7 @@ extensions:
           peer: CircuitService
           cardinality: many
           optional: true
-    - kind: CircuitEndpoint
+    - kind: DcimCircuitEndpoint
       relationships:
         - name: circuit_service
           peer: CircuitService

--- a/experimental/modules_routing_engine/routing_engine.yml
+++ b/experimental/modules_routing_engine/routing_engine.yml
@@ -27,11 +27,13 @@ nodes:
       - ["serial_number__value"]
       #  # Only one RE per Device RE-Slot
       # - ["device", "slot__value"]
+    # `serial_number` is inherited from DeviceGenericModule and unique, matching
+    # the uniqueness constraint above. `device` peers to the DcimPhysicalDevice
+    # generic, which carries `serial` but no `name`.
     human_friendly_id:
-      - device__name__value
-      - slot__value
+      - serial_number__value
     order_by:
-      - device__name__value
+      - device__serial__value
       - slot__value
     display_label: serial_number__value
     attributes:


### PR DESCRIPTION
## What

Two experimental extensions cannot be loaded into Infrahub at all. Both are published to the [Infrahub marketplace](https://marketplace.infrahub.app), where they break the install check for the `infrahub/circuits-peering` and `infrahub/physical-cabling` Collections.

### `experimental/circuit_service`

```text
Unable to load the schema:
  Unable to find the schema 'CircuitEndpoint' in the registry
```

`CircuitEndpoint` is defined in `extensions/circuit/circuit.yml:82` with `namespace: Dcim`, so its resolved kind is `DcimCircuitEndpoint` — which is exactly how `circuit.yml:77` refers to it. `circuit_service.yml` referenced it bare in two places, so the reference never resolved.

### `experimental/modules_routing_engine`

```text
Unable to load the schema:
  DeviceRoutingEngine.order_by: name is not a valid attribute of DcimPhysicalDevice
```

`DeviceRoutingEngine` inherits `device` from `DeviceGenericModule`, which peers to the `DcimPhysicalDevice` generic (`extensions/modules/modules.yml:61`). That generic carries `position`, `serial` and `rack_face` — `name` lives on `DcimGenericDevice`. Both `human_friendly_id` and `order_by` traversed `device__name__value`.

Adding `name` to `DcimPhysicalDevice` is not a viable fix: nodes inherit both generics (`base/dcim.yml:429-430`), so it would collide with the existing attribute.

So:

- `human_friendly_id` → `serial_number__value`, matching the node's own uniqueness constraint and the `DeviceGenericModule` default. The old value had no uniqueness constraint behind it either way — the device/slot one is commented out.
- `order_by` → `device__serial__value`, keeping the grouping-by-device intent using an attribute the declared peer actually has. This mirrors how the sibling linecards extension orders through a parent (`linecard__serial_number__value`).

`DeviceLinecard` inherits the same generic but never traverses `device__name__value`, so it is unaffected — as are `patch_panel`, `dwdm` and `optical_transport`, which inherit `DcimPhysicalDevice` without that traversal.

## Why CI never caught this

`invoke schemas.load-all-schemas` skips everything under `experimental/` unless `TEST_EXPERIMENTAL` is set (`tasks/schemas.py:92`), and CI does not set it. These extensions are published to the marketplace regardless, so the only place the breakage surfaces is downstream. Worth deciding separately whether the load test should cover `experimental/` — this PR does not change that.

## Verification

Ran `infrahubctl schema check` over each extension's full transitive dependency closure (from `.metadata.yml`, matching what the marketplace ships as the Collection bundle) against a throwaway Infrahub via `infrahub-testcontainers`:

| Extension | before | after |
|---|---|---|
| `experimental/circuit_service` | ❌ `Unable to find the schema 'CircuitEndpoint'` | ✅ |
| `experimental/modules_routing_engine` | ❌ `DeviceRoutingEngine.order_by: name is not a valid attribute` | ✅ |

Both errors reproduced verbatim against unfixed `main` first, so the check is not vacuous. `infrahubctl schema check` always exits 0, so the assertion greps the output for load-error text.

Reference docs regenerated with `invoke docs.generate`. That command also produces unrelated diffs in `dcim.mdx`, `security.mdx`, `lag.mdx`, `mlag.mdx`, `sfp.mdx`, `optical_transport.mdx`, `circuit_contract.mdx` and `home.mdx` from earlier commits that did not regenerate; those are left out of this PR. Note the `check-documentation` job diffs `docs/reference/` while the files live in `docs/docs/reference/`, so that drift currently goes unnoticed.

## Downstream

Unblocks opsmill/infrahub-marketplace#110 and opsmill/infrahub-marketplace#116, the two known reds in that repo's Collection install check. They clear once this lands and the schema-library sync re-publishes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
