### PR TITLE
fix(docs): escape MDX braces in generated reference pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
         run: "uv run mypy --show-error-codes ."
       - name: "Pylint Tests"
         run: "uv run pylint --ignore .venv ."
+      - name: "Unit Tests"
+        run: "uv run pytest"
 
   yaml-lint:
     name: Run yaml lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,16 @@ dev = [
     "pylint>=4.0.4",
     "vale>=3.13.0.0",
     "types-pyyaml>=6.0.12.20250915",
+    # Covers the docs-generation helpers in tasks/, whose escaping rules are
+    # subtle enough to regress without being noticed until a docs build fails.
+    "pytest>=8.3.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# `tasks` is a top-level package in the repo root rather than an installed
+# distribution, so the root has to be on the import path for the tests.
+pythonpath = ["."]
 
 [tool.pylint.messages_control]
 # Line length is enforced by Black, so pylint doesn't need to check it.

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -1,6 +1,8 @@
+import re
 import sys
 from collections import defaultdict
 from pathlib import Path
+from typing import Any
 
 import jinja2
 import yaml  # type: ignore
@@ -12,11 +14,68 @@ METADATA_FILE = CURRENT_DIRECTORY.parent / ".metadata.yml"
 TEMPLATE_DIRECTORY = DOCUMENTATION_DIRECTORY / "_templates"
 REFERENCE_DIRECTORY = DOCUMENTATION_DIRECTORY / "docs" / "reference"
 
+# Matches an inline code span: a run of backticks, the shortest content that
+# reaches a matching run, and the closing run. DOTALL so a span may wrap lines.
+INLINE_CODE_PATTERN = re.compile(r"(?P<fence>`+).*?(?P=fence)", re.DOTALL)
+
 
 def _sanitize_description(desc):
     if not isinstance(desc, str):
         return desc
     return desc.replace("\n", " ").replace("  ", " ").strip()
+
+
+def _escape_mdx_braces(text: str) -> str:
+    """Escape MDX expression braces that sit outside inline code spans.
+
+    Docusaurus parses the reference pages as MDX, where a bare ``{...}`` is a
+    JSX expression rather than literal text. A schema description carrying
+    braces -- NetBox's ``Ethernet{module}/1`` port-name token, say -- therefore
+    breaks the docs build with "Objects are not valid as a React child", because
+    ``module`` resolves to the MDX module object.
+
+    Braces inside an inline code span are already inert, and a backslash there
+    would render literally rather than escaping, so those spans are left alone.
+
+    Args:
+        text: Text destined for MDX prose or a Markdown table cell.
+
+    Returns:
+        The text with braces outside inline code spans backslash-escaped.
+    """
+    if not isinstance(text, str) or ("{" not in text and "}" not in text):
+        return text
+
+    def escape(segment: str) -> str:
+        return segment.replace("{", "\\{").replace("}", "\\}")
+
+    parts: list[str] = []
+    position = 0
+    for match in INLINE_CODE_PATTERN.finditer(text):
+        parts.append(escape(text[position : match.start()]))
+        parts.append(match.group(0))
+        position = match.end()
+    parts.append(escape(text[position:]))
+
+    return "".join(parts)
+
+
+def _escape_mdx_structure(value: Any) -> Any:
+    """Recursively apply :func:`_escape_mdx_braces` to every string in a value.
+
+    Args:
+        value: Any nested combination of dicts, lists and scalars.
+
+    Returns:
+        The same shape, with every string escaped for MDX.
+    """
+    if isinstance(value, str):
+        return _escape_mdx_braces(value)
+    if isinstance(value, list):
+        return [_escape_mdx_structure(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _escape_mdx_structure(item) for key, item in value.items()}
+    return value
 
 
 def _generate_toc_content(metadata) -> defaultdict[str, list]:
@@ -30,9 +89,11 @@ def _generate_toc_content(metadata) -> defaultdict[str, list]:
     for key in metadata:
         # TODO: Handle the case where we can't split the key
         current_item = {
-            "name": metadata[key].get("name"),
+            "name": _escape_mdx_braces(metadata[key].get("name")),
             "link": "./reference/" + key.split("/")[1] + ".mdx",
-            "description": _sanitize_description(metadata[key].get("description", "")),
+            "description": _escape_mdx_braces(
+                _sanitize_description(metadata[key].get("description", ""))
+            ),
         }
 
         result[key.split("/")[0]].append(current_item)
@@ -91,6 +152,12 @@ def _generate_schema_reference_content(schema_key: str, schema_metadata: dict) -
         # Extract nodes, generics, and extensions if present
         for section in ["nodes", "generics", "extensions"]:
             schema_data[section] = schema_definition.get(section, [])
+
+        # Everything above is rendered as MDX prose or into a Markdown table,
+        # so braces in it have to be escaped. The code section below is not:
+        # it lands inside a fenced block, where MDX leaves braces alone and an
+        # escape would show up verbatim in the rendered YAML.
+        schema_data = _escape_mdx_structure(schema_data)
 
         # Add the code section
         schema_data["code"] = yaml.dump(schema_definition, sort_keys=False)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,80 @@
+"""Tests for the documentation generation helpers in ``tasks.docs``."""
+
+import pytest
+
+from tasks.docs import _escape_mdx_braces, _escape_mdx_structure
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        pytest.param("no braces here", "no braces here", id="untouched"),
+        pytest.param(
+            "e.g. 'Ethernet{module}/1'.",
+            "e.g. 'Ethernet\\{module\\}/1'.",
+            id="bare-braces-escaped",
+        ),
+        pytest.param(
+            "e.g. `Ethernet{module}/1`.",
+            "e.g. `Ethernet{module}/1`.",
+            id="inline-code-left-alone",
+        ),
+        pytest.param(
+            "{a} then `{b}` then {c}",
+            "\\{a\\} then `{b}` then \\{c\\}",
+            id="mixed-inside-and-outside",
+        ),
+        pytest.param(
+            "``a ` b {c}``",
+            "``a ` b {c}``",
+            id="double-backtick-span-with-embedded-backtick",
+        ),
+        pytest.param(
+            "{{ device__name__value }}",
+            "\\{\\{ device__name__value \\}\\}",
+            id="jinja-style-double-braces",
+        ),
+        pytest.param(
+            "unterminated `code {x}",
+            "unterminated `code \\{x\\}",
+            id="unclosed-span-still-escaped",
+        ),
+    ],
+)
+def test_escape_mdx_braces(text: str, expected: str) -> None:
+    assert _escape_mdx_braces(text) == expected
+
+
+@pytest.mark.parametrize("value", [None, 42, True])
+def test_escape_mdx_braces_passes_through_non_strings(value: object) -> None:
+    assert _escape_mdx_braces(value) is value  # type: ignore[arg-type]
+
+
+def test_escape_mdx_structure_walks_nested_containers() -> None:
+    payload = {
+        "description": "a {token}",
+        "nodes": [
+            {"name": "Node", "attributes": [{"description": "b {token}"}]},
+            {"name": "Safe", "attributes": [{"description": "c `{token}`"}]},
+        ],
+        "optional": True,
+        "order_weight": 1000,
+    }
+
+    result = _escape_mdx_structure(payload)
+
+    assert result["description"] == "a \\{token\\}"
+    assert result["nodes"][0]["attributes"][0]["description"] == "b \\{token\\}"
+    # Inline code spans survive the walk unchanged.
+    assert result["nodes"][1]["attributes"][0]["description"] == "c `{token}`"
+    # Non-string scalars are preserved, not stringified.
+    assert result["optional"] is True
+    assert result["order_weight"] == 1000
+
+
+def test_escape_mdx_structure_does_not_mutate_input() -> None:
+    payload = {"description": "a {token}"}
+
+    _escape_mdx_structure(payload)
+
+    assert payload["description"] == "a {token}"

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -856,6 +856,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pylint" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "vale" },
@@ -873,6 +874,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pylint", specifier = ">=4.0.4" },
+    { name = "pytest", specifier = ">=8.3.0" },
     { name = "ruff", specifier = ">=0.14.10" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "vale", specifier = ">=3.13.0.0" },


### PR DESCRIPTION
## Problem

Docusaurus parses the generated reference pages as MDX, where a bare `{...}` is a JSX expression rather than literal text. Any schema description containing braces breaks the docs build:

```
Error: Can't render static file for pathname "/reference/module_port"
  cause: Objects are not valid as a React child (found: object with keys {children, exports})
```

`module` happens to be a real binding in MDX module scope, so a NetBox port-name token like `Ethernet{module}/1` silently renders the MDX module object instead of failing on an undefined name.

Found while rebasing #76, whose `module_port` extension is the first schema in the library to put braces in a description.

## Why the existing CI doesn't protect against this

`Check generated documentation is up to date` passes happily, because the regenerated MDX matches the committed MDX — the docs are consistently generated and consistently unbuildable. Only `validate-documentation`, which runs afterwards, catches it. Anyone writing a braced description hits this at the very end of a CI run, with an error that names React rather than their schema.

## Changes

### `tasks/docs.py`

Escape braces in everything rendered as MDX prose or into a Markdown table. Two things are deliberately left alone:

- **The `code` section.** It lands inside a fenced block, where MDX ignores braces and an escape would show up verbatim in the rendered YAML. This matters — several schemas have `jinja2_template: "{{ device__name__value }}"`, which must survive intact.
- **Inline code spans.** Braces inside them are already inert, and a backslash there renders literally rather than escaping. Blindly escaping would corrupt a description that had already worked around this with backticks (as `module_port` does in #76).

### `tests/`, `pyproject.toml`, `.github/workflows/ci.yml`

Those two carve-outs are subtle enough to regress unnoticed, so they get unit tests — the repo's first. Adds `pytest` to the dev group, points it at the repo root so the top-level `tasks` package imports, and runs it in the existing `python-lint` job.

## Verification

**This changes no generated output.** No description on `main` contains braces today, so regenerating produces a zero-line diff. It removes a trap rather than fixing a visible symptom.

Proven by temporarily giving `extensions/cable/cable.yml` an unbackticked description:

```yaml
description: "Probe: port name e.g. 'Ethernet{module}/1' plus {a}."
```

Generated MDX — escaped in prose, untouched in the code fence:

```
17:- **Description:** Probe: port name e.g. 'Ethernet\{module\}/1' plus \{a\}.
40:  description: 'Probe: port name e.g. ''Ethernet{module}/1'' plus {a}.'
```

`npm run build` then succeeds where it previously failed, and the rendered HTML contains the literal `Ethernet{module}/1 plus {a}` with zero `[object Object]` and no leaked backslashes. Probe reverted before committing.

`ruff`, `ruff format`, `mypy`, `pylint` (10.00/10), `yamllint` and 12 unit tests all pass.

## Notes for reviewers

- The CI line is one step in the existing `python-lint` job. If you'd rather tests live in their own job, or not run in CI yet, that step is trivially droppable without touching the fix.
- Related but deliberately **not** fixed here: `invoke docs.generate` also overwrites every `extensions/*/README.md` with a fixed stub, clobbering hand-written notes in `location_minimal`, `location_site` and `rack`. And `docs/docs/reference/security.mdx` is stale against its schema. Both are separate pre-existing issues.
